### PR TITLE
Add support for handling and enforcing rate limiting

### DIFF
--- a/commercelayer/provider.go
+++ b/commercelayer/provider.go
@@ -41,7 +41,7 @@ var baseSchema = map[string]*schema.Schema{
 	"rate_limiter": {
 		Type:        schema.TypeBool,
 		Optional:    true,
-		DefaultFunc: schema.EnvDefaultFunc("COMMERCELAYER_RATE_LIMITER", false),
+		DefaultFunc: schema.EnvDefaultFunc("COMMERCELAYER_RATE_LIMITER", true),
 		Description: "Enable rate limiting when hitting commerce layer",
 	},
 }

--- a/commercelayer/rate_limiter.go
+++ b/commercelayer/rate_limiter.go
@@ -1,6 +1,7 @@
 package commercelayer
 
 import (
+	"errors"
 	"net/http"
 	"sync"
 	"time"
@@ -21,7 +22,7 @@ func (t *throttledTransport) RoundTrip(req *http.Request) (*http.Response, error
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	for {
+	for i := 0; i < 5; i++ {
 		resp, err := t.transport.RoundTrip(req)
 		if err != nil {
 			return nil, err
@@ -40,4 +41,6 @@ func (t *throttledTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 		time.Sleep(interval)
 	}
+
+	return nil, errors.New("max retries reached when trying to handle rate limiting")
 }

--- a/commercelayer/rate_limiter.go
+++ b/commercelayer/rate_limiter.go
@@ -1,0 +1,43 @@
+package commercelayer
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// throttledTransport embeds the underlying transport
+// and regulates requests to respect rate limits.
+type throttledTransport struct {
+	transport http.RoundTripper
+	mutex     sync.Mutex
+}
+
+// RoundTrip executes an HTTP request, and if the response indicates rate
+// limiting (HTTP 429), it waits for the retry interval specified in the
+// "X-Ratelimit-Interval" header before retrying. It locks a mutex to ensure
+// only one request is processed at a time.
+func (t *throttledTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	for {
+		resp, err := t.transport.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		interval, err := time.ParseDuration(resp.Header.Get("X-Ratelimit-Interval") + "s")
+		if err != nil {
+			return resp, nil
+		}
+
+		resp.Body.Close()
+
+		time.Sleep(interval)
+	}
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ The provider attempts to read the required values from environment variables:
 - `COMMERCELAYER_CLIENT_SECRET`
 - `COMMERCELAYER_API_ENDPOINT`
 - `COMMERCELAYER_AUTH_ENDPOINT`
+- `COMMERCELAYER_RATE_LIMITER`
 
 Alternatively, you can set it up directly in the terraform file:
 
@@ -44,6 +45,7 @@ provider "commercelayer" {
     client_secret = "<client_secret>"
     api_endpoint  = "<api_endpoint>"
     auth_endpoint = "<auth_endpoint>"
+    rate_limiter  = "true|false"
 }
 ```
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -35,6 +35,7 @@ The provider attempts to read the required values from environment variables:
 - `COMMERCELAYER_CLIENT_SECRET`
 - `COMMERCELAYER_API_ENDPOINT`
 - `COMMERCELAYER_AUTH_ENDPOINT`
+- `COMMERCELAYER_RATE_LIMITER`
 
 Alternatively, you can set it up directly in the terraform file:
 
@@ -44,6 +45,7 @@ provider "commercelayer" {
     client_secret = "<client_secret>"
     api_endpoint  = "<api_endpoint>"
     auth_endpoint = "<auth_endpoint>"
+    rate_limiter  = "true|false"
 }
 ```
 


### PR DESCRIPTION
Hello,

This is a naive and simple implementation to handle rate-limiting rules at the transport level.

The rate-limiting rules are described in this [documentation page](https://docs.commercelayer.io/core/rate-limits).

Also for context, the only existing implementation I found was in the SDK utils repo officially managed by CommerceLayer. Here it is:

https://github.com/commercelayer/commercelayer-sdk-utils/blob/e941ac5683b5c6e4fd67797c21975fde5e2462cd/src/batch.ts#L229

Note that this lib is used in the official typescript CLI.

In this typescript implementation, they implemented a principle of "batch tasks". So when you know exactly in advance the number of resources to create in CommerceLayer, you can group them in a "batch", and this batch will execute the calls to the API by spreading the requests in time to stay within the rate limit constraints.

In simple words, if you know that you can send only 10 requests per second, you can send one request every 100 milliseconds. That is what this "batch" algorithm does. To get the exact constraint values, the SDK get them by retrieving the response headers named `X-Ratelimit-Limit` and `X-Ratelimit-Interval` as documented on the above page.

Having this context in mind, I want to explain why I went the "naive" route with my implementation instead of mimicking the SDK implementation.

In Terraform, rate-limiting enforcement is hard. That is why it is not officially supported. See [this issue](https://github.com/hashicorp/terraform/issues/31094) for more context. But in a few words, Terraform works by first "planning" what should be done by comparing the current configuration with the last state recorded. It then builds a "plan" that will have to be executed by a provider to enforce the new state. And the provider is tasked to do the work. In our example, the CommerceLayer provider issues HTTP requests to the CommerceLayer API.

So Terraform is the "manager" here, and the provider is the "executor". Terraform simply tells the provider to: "create that resource", or "delete that specific resource". At the provider level, there is no correlation between requests, so it is not possible in a simple way to say: "Execute that request, then wait 100ms and finally execute that second one". I hope that this is clear.

To circumvent this, there are potential strategies:
1. Being able to calculate the acceptable throughput (with the returned response headers), we can end each request by waiting for the precomputed amount of time.
2. We can add a field on the `transport` struct to retain the date/time of the last request that was executed to calculate if we should wait for this new one.

The first point to raise here is whatever strategy, we have to coordinate and "fan-in" requests so that only one is performed at a time (hence the usage of a mutex). Otherwise, we are not able to control the actual throughput. This is a downside as Terraform will try to parallelize work by default.

To complicate the topic even more, the documentation of rate limiting says that:

> Two kinds of rate limits are applied to the IP with which you perform the calls to the /api/* endpoints:
> Average — the number of requests is calculated considering the sum of the requests sent to all the resource endpoints.
> Burst — the number of requests is calculated on each single resource endpoint of the specific class

This adds complexity even more. Now we have to keep track of the global amount of requests so that we respect the average number of requests performed, and we also have to keep track of burst limits that are per resource and per operation (aka HTTP method such as POST, GET, DELETE, ...).

I tried to go down the road of the second strategy by taking into account those two different rate limit types. I ended up with more than 300 lines of Go code with maps associated with the transport struct to keep track of the state of each type of limit. That was awful, hard to understand and hardly maintainable. But it was "working" though. No more 429 (too many requests).

Then, I came back to thinking about this constraint of making sure that only one request is executed at a time. And I told to myself: "Let’s try the naive algorithm". This algorithm is what is implemented in this PR. The code is around 40 lines of "simple" Go code. And to my surprise, the result was not that bad when trying it. No more 429 either, but the throughput was not considerably lower than my previous implementation.

So here is my proposal to add this implementation for rate limiting. It is not perfect, but it is not that bad considering Terraform design and constraints.

Also, I have put this under feature toggle as it brings a lot of latency by forcing one request at a time. So to enable it, one could add this `rate_limiter` variable to the definition of the provider:

```
provider "commercelayer" {
    client_id     = var.COMMERCELAYER_CLIENT_ID
    client_secret = var.COMMERCELAYER_CLIENT_SECRET
    api_endpoint  = var.COMMERCELAYER_API_ENDPOINT
    auth_endpoint = var.COMMERCELAYER_AUTH_ENDPOINT
    rate_limiter  = true
}
```

I will finish with the last word. My company has chosen CommerceLayer for its eCommerce and I did all that analysis and implementation in that context. As we have access to CommerceLayer support, I had the chance to have a call with the CTO of CommerceLayer to explain my concern. Of course, your provider does not belong to them, so they could only advise but they could also explain better their rate-limiting design and algorithm.

What I propose here is a good balance of simplicity, ease of maintenance and sufficiently practical implementation.