### PR TITLE
feat: add new fields to inventory model

### DIFF
--- a/commercelayer/resource_inventory_model.go
+++ b/commercelayer/resource_inventory_model.go
@@ -56,6 +56,12 @@ func resourceInventoryModel() *schema.Resource {
 							Optional:    true,
 							Default:     2,
 						},
+						"stock_reservation_cutoff": {
+							Description: "The duration in seconds of the generated stock reservations.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     3600,
+						},
 						"reference": {
 							Description: "A string that you can use to add any external identifier to the resource. This " +
 								"can be useful for integrating the resource to an external system, like an ERP, a " +
@@ -67,6 +73,18 @@ func resourceInventoryModel() *schema.Resource {
 							Description: "Any identifier of the third party system that defines the reference code",
 							Type:        schema.TypeString,
 							Optional:    true,
+						},
+						"manual_stock_decrement": {
+							Description: "Indicates if the the stock will be decremented manually after the order approval",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+						"put_stock_transfers_on_hold": {
+							Description: "Indicates if the the stock transfers must be put on hold automatically with the associated shipment.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
 						},
 						"metadata": {
 							Description: "Set of key-value pairs that you can attach to the resource. This can be useful " +
@@ -112,12 +130,15 @@ func resourceInventoryModelCreateFunc(ctx context.Context, d *schema.ResourceDat
 		Data: commercelayer.InventoryModelCreateData{
 			Type: inventoryModelType,
 			Attributes: commercelayer.POSTInventoryModels201ResponseDataAttributes{
-				Name:                 attributes["name"].(string),
-				Strategy:             stringRef(attributes["strategy"]),
-				StockLocationsCutoff: intToInt32Ref(attributes["stock_locations_cutoff"]),
-				Reference:            stringRef(attributes["reference"]),
-				ReferenceOrigin:      stringRef(attributes["reference_origin"]),
-				Metadata:             keyValueRef(attributes["metadata"]),
+				Name:                    attributes["name"].(string),
+				Strategy:                stringRef(attributes["strategy"]),
+				StockLocationsCutoff:    intToInt32Ref(attributes["stock_locations_cutoff"]),
+				Reference:               stringRef(attributes["reference"]),
+				ReferenceOrigin:         stringRef(attributes["reference_origin"]),
+				ManualStockDecrement:    boolRef(attributes["manual_stock_decrement"]),
+				StockReservationCutoff:  intToInt32Ref(attributes["stock_reservation_cutoff"]),
+				PutStockTransfersOnHold: boolRef(attributes["put_stock_transfers_on_hold"]),
+				Metadata:                keyValueRef(attributes["metadata"]),
 			},
 		},
 	}
@@ -153,12 +174,15 @@ func resourceInventoryModelUpdateFunc(ctx context.Context, d *schema.ResourceDat
 			Type: inventoryModelType,
 			Id:   d.Id(),
 			Attributes: commercelayer.PATCHInventoryModelsInventoryModelId200ResponseDataAttributes{
-				Name:                 stringRef(attributes["name"]),
-				Strategy:             stringRef(attributes["strategy"]),
-				StockLocationsCutoff: intToInt32Ref(attributes["stock_locations_cutoff"]),
-				Reference:            stringRef(attributes["reference"]),
-				ReferenceOrigin:      stringRef(attributes["reference_origin"]),
-				Metadata:             keyValueRef(attributes["metadata"]),
+				Name:                    stringRef(attributes["name"]),
+				Strategy:                stringRef(attributes["strategy"]),
+				StockLocationsCutoff:    intToInt32Ref(attributes["stock_locations_cutoff"]),
+				Reference:               stringRef(attributes["reference"]),
+				ReferenceOrigin:         stringRef(attributes["reference_origin"]),
+				ManualStockDecrement:    boolRef(attributes["manual_stock_decrement"]),
+				StockReservationCutoff:  intToInt32Ref(attributes["stock_reservation_cutoff"]),
+				PutStockTransfersOnHold: boolRef(attributes["put_stock_transfers_on_hold"]),
+				Metadata:                keyValueRef(attributes["metadata"]),
 			},
 		},
 	}

--- a/commercelayer/resource_inventory_model_test.go
+++ b/commercelayer/resource_inventory_model_test.go
@@ -44,6 +44,9 @@ func (s *AcceptanceSuite) TestAccInventoryModel_basic() {
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.name", "Incentro Inventory Model"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.stock_locations_cutoff", "1"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.strategy", "no_split"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.manual_stock_decrement", "true"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.stock_reservation_cutoff", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.put_stock_transfers_on_hold", "true"),
 				),
 			},
 			{
@@ -52,6 +55,9 @@ func (s *AcceptanceSuite) TestAccInventoryModel_basic() {
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.name", "Incentro Inventory Model Changed"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.stock_locations_cutoff", "2"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.strategy", "split_shipments"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.manual_stock_decrement", "false"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.stock_reservation_cutoff", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.put_stock_transfers_on_hold", "false"),
 				),
 			},
 		},
@@ -65,6 +71,9 @@ func testAccInventoryModelCreate(testName string) string {
 			name                   = "Incentro Inventory Model"
 			stock_locations_cutoff = 1
 			strategy               = "no_split"
+			manual_stock_decrement = true
+			stock_reservation_cutoff = 4000
+			put_stock_transfers_on_hold = true
 			metadata = {
 			  testName: "{{.testName}}"
 			}
@@ -80,6 +89,9 @@ func testAccInventoryModelUpdate(testName string) string {
 			name                   = "Incentro Inventory Model Changed"
 			stock_locations_cutoff = 2
 			strategy               = "split_shipments"
+			manual_stock_decrement = false
+			stock_reservation_cutoff = 3600
+			put_stock_transfers_on_hold = false
 			metadata = {
 			  testName: "{{.testName}}"
 			}

--- a/examples/resources/commercelayer_inventory_model/resource.tf
+++ b/examples/resources/commercelayer_inventory_model/resource.tf
@@ -1,7 +1,10 @@
 resource "commercelayer_inventory_model" "incentro_inventory_model" {
   attributes {
-    name                   = "Incentro Inventory Model"
-    stock_locations_cutoff = 2
-    strategy               = "split_shipments"
+    name                        = "Incentro Inventory Model"
+    stock_locations_cutoff      = 2
+    strategy                    = "split_shipments"
+    manual_stock_decrement      = true
+    stock_reservation_cutoff    = 4000
+    put_stock_transfers_on_hold = true
   }
 }


### PR DESCRIPTION
Hi everyone, 

First of all, great job on the Commerce Layer Terraform provider, makes our job a lot easier 👏

I hope you don't mind I took the liberty to create this PR for #111 . I thought it was a nice way to learn about the workings of the project. 

This PR adds some fields that were recently introduced to the **Inventory Model.**

- manual_stock_decrement
- stock_reservation_cutoff
- put_stock_transfers_on_hold

https://docs.commercelayer.io/core/api-reference/inventory_models/object

