### PR TITLE
feat: add code and shipping costs cutoff to Market

### DIFF
--- a/commercelayer/resource_market.go
+++ b/commercelayer/resource_market.go
@@ -42,6 +42,11 @@ func resourceMarket() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 						},
+						"code": {
+							Description: "A string that you can use to identify the market (must be unique within the environment).",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
 						"facebook_pixel_id": {
 							Description: "The Facebook Pixed ID",
 							Type:        schema.TypeString,
@@ -60,6 +65,11 @@ func resourceMarket() *schema.Resource {
 						"external_order_validation_url": {
 							Description: "The URL used to validate orders by an external source.",
 							Type:        schema.TypeString,
+							Optional:    true,
+						},
+						"shipping_cost_cutoff": {
+							Description: "When specified indicates the maximum number of shipping line items with cost that will be added to an order.",
+							Type:        schema.TypeInt,
 							Optional:    true,
 						},
 						"reference": {
@@ -157,9 +167,11 @@ func resourceMarketCreateFunc(ctx context.Context, d *schema.ResourceData, i int
 			Attributes: commercelayer.POSTMarkets201ResponseDataAttributes{
 				Name:                       attributes["name"].(string),
 				FacebookPixelId:            stringRef(attributes["facebook_pixel_id"]),
+				Code:                       stringRef(attributes["code"]),
 				CheckoutUrl:                stringRef(attributes["checkout_url"]),
 				ExternalPricesUrl:          stringRef(attributes["external_prices_url"]),
 				ExternalOrderValidationUrl: stringRef(attributes["external_order_validation_url"]),
+				ShippingCostCutoff:         intToInt32Ref(attributes["shipping_cost_cutoff"]),
 				Reference:                  stringRef(attributes["reference"]),
 				ReferenceOrigin:            stringRef(attributes["reference_origin"]),
 				Metadata:                   keyValueRef(attributes["metadata"]),
@@ -238,10 +250,12 @@ func resourceMarketUpdateFunc(ctx context.Context, d *schema.ResourceData, i int
 			Id:   d.Id(),
 			Attributes: commercelayer.PATCHMarketsMarketId200ResponseDataAttributes{
 				Name:                       stringRef(attributes["name"]),
+				Code:                       stringRef(attributes["code"]),
 				FacebookPixelId:            stringRef(attributes["facebook_pixel_id"]),
 				CheckoutUrl:                stringRef(attributes["checkout_url"]),
 				ExternalPricesUrl:          stringRef(attributes["external_prices_url"]),
 				ExternalOrderValidationUrl: stringRef(attributes["external_order_validation_url"]),
+				ShippingCostCutoff:         intToInt32Ref(attributes["shipping_cost_cutoff"]),
 				Reference:                  stringRef(attributes["reference"]),
 				ReferenceOrigin:            stringRef(attributes["reference_origin"]),
 				Metadata:                   keyValueRef(attributes["metadata"]),

--- a/commercelayer/resource_market_test.go
+++ b/commercelayer/resource_market_test.go
@@ -75,10 +75,15 @@ func testAccMarketCreate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_market" "incentro_market" {
 		  attributes {
+			code = "M-001"
 			name              = "Incentro Market"
 			facebook_pixel_id = "pixel"
-            external_order_validation_url = "https://www.example.com"
-
+			checkout_url = "https://www.checkout.com/:order_id"            
+			external_order_validation_url = "https://www.example.com"
+			external_prices_url = "https://www.prices.com"
+			shipping_cost_cutoff = 100
+			reference = "M-001-EXT"
+			reference_origin = "ERP"
 			metadata = {
 			  testName: "{{.testName}}"
 			}
@@ -97,10 +102,15 @@ func testAccMarketUpdate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_market" "incentro_market" {
 		  attributes {
+			code = "M-001-CHG"
 			name              = "Incentro Market Changed"
 			facebook_pixel_id = "pixelchanged"
-            external_order_validation_url = "https://www.example.com"
-
+			checkout_url = "https://www.checkout-changed.com/:order_id"            
+			external_order_validation_url = "https://www.example-changed.com"
+			external_prices_url = "https://www.prices-changed.com"
+			shipping_cost_cutoff = 105
+			reference = "M-001-EXT-CHG"
+			reference_origin = "ERP-CHG"
 			metadata = {
 			  testName: "{{.testName}}"
 			}

--- a/mock/mappings/api_markets-1a87d54e-5d2d-4bf8-b762-1813dff8f641.json
+++ b/mock/mappings/api_markets-1a87d54e-5d2d-4bf8-b762-1813dff8f641.json
@@ -5,7 +5,7 @@
     "url" : "/api/markets",
     "method" : "POST",
     "bodyPatterns" : [ {
-      "equalToJson" : "{\"data\":{\"attributes\":{\"checkout_url\":null,\"external_order_validation_url\":\"https://www.example.com\",\"external_prices_url\":null,\"facebook_pixel_id\":\"pixel\",\"metadata\":{\"testName\":\"commercelayer_market.incentro_market\"},\"name\":\"Incentro Market\",\"reference\":null,\"reference_origin\":null},\"relationships\":{\"inventory_model\":{\"data\":{\"id\":\"kZXEvSyREa\",\"type\":\"inventory_models\"}},\"merchant\":{\"data\":{\"id\":\"qnzZLHQmpn\",\"type\":\"merchants\"}},\"price_list\":{\"data\":{\"id\":\"AkYYaCErEk\",\"type\":\"price_lists\"}}},\"type\":\"markets\"}}\n",
+      "equalToJson" : "{\"data\":{\"attributes\":{\"code\":\"M-001\",\"shipping_cost_cutoff\":100,\"checkout_url\":\"https://www.checkout.com/:order_id\",\"external_order_validation_url\":\"https://www.example.com\",\"external_prices_url\":\"https://www.prices.com\",\"facebook_pixel_id\":\"pixel\",\"metadata\":{\"testName\":\"commercelayer_market.incentro_market\"},\"name\":\"Incentro Market\",\"reference\":\"M-001-EXT\",\"reference_origin\":\"ERP\"},\"relationships\":{\"inventory_model\":{\"data\":{\"id\":\"kZXEvSyREa\",\"type\":\"inventory_models\"}},\"merchant\":{\"data\":{\"id\":\"qnzZLHQmpn\",\"type\":\"merchants\"}},\"price_list\":{\"data\":{\"id\":\"AkYYaCErEk\",\"type\":\"price_lists\"}}},\"type\":\"markets\"}}\n",
       "ignoreArrayOrder" : true,
       "ignoreExtraElements" : true
     } ]

--- a/mock/mappings/api_markets_xjbdyhlyol-2329486c-1492-47cc-a608-519ef1c30e58.json
+++ b/mock/mappings/api_markets_xjbdyhlyol-2329486c-1492-47cc-a608-519ef1c30e58.json
@@ -5,7 +5,7 @@
     "url" : "/api/markets/XjBdyhLYOl",
     "method" : "PATCH",
     "bodyPatterns" : [ {
-      "equalToJson" : "{\"data\":{\"attributes\":{\"checkout_url\":null,\"external_order_validation_url\":\"https://www.example.com\",\"external_prices_url\":null,\"facebook_pixel_id\":\"pixelchanged\",\"metadata\":{\"testName\":\"commercelayer_market.incentro_market\"},\"name\":\"Incentro Market Changed\",\"reference\":null,\"reference_origin\":null},\"id\":\"XjBdyhLYOl\",\"relationships\":{\"inventory_model\":{\"data\":{\"id\":\"kZXEvSyREa\",\"type\":\"inventory_models\"}},\"merchant\":{\"data\":{\"id\":\"qnzZLHQmpn\",\"type\":\"merchants\"}},\"price_list\":{\"data\":{\"id\":\"AkYYaCErEk\",\"type\":\"price_lists\"}}},\"type\":\"markets\"}}\n",
+      "equalToJson" : "{\"data\":{\"attributes\":{\"code\":\"M-001-CHG\",\"shipping_cost_cutoff\":105,\"checkout_url\":\"https://www.checkout-changed.com/:order_id\",\"external_order_validation_url\":\"https://www.example-changed.com\",\"external_prices_url\":\"https://www.prices-changed.com\",\"facebook_pixel_id\":\"pixelchanged\",\"metadata\":{\"testName\":\"commercelayer_market.incentro_market\"},\"name\":\"Incentro Market Changed\",\"reference\":\"M-001-EXT-CHG\",\"reference_origin\":\"ERP-CHG\"},\"id\":\"XjBdyhLYOl\",\"relationships\":{\"inventory_model\":{\"data\":{\"id\":\"kZXEvSyREa\",\"type\":\"inventory_models\"}},\"merchant\":{\"data\":{\"id\":\"qnzZLHQmpn\",\"type\":\"merchants\"}},\"price_list\":{\"data\":{\"id\":\"AkYYaCErEk\",\"type\":\"price_lists\"}}},\"type\":\"markets\"}}\n",
       "ignoreArrayOrder" : true,
       "ignoreExtraElements" : true
     } ]


### PR DESCRIPTION
This PR should partly fix #108 and adds some fields that were recently introduced to the Market.

- code
- shipping_cost_cutoff

https://docs.commercelayer.io/core/api-reference/markets/object
